### PR TITLE
Fix date selection from initialization

### DIFF
--- a/rangedatepicker/src/main/java/com/andrewjapar/rangedatepicker/CalendarEntityExtensions.kt
+++ b/rangedatepicker/src/main/java/com/andrewjapar/rangedatepicker/CalendarEntityExtensions.kt
@@ -1,0 +1,13 @@
+package com.andrewjapar.rangedatepicker
+
+import java.util.*
+
+internal fun CalendarEntity.Day.isTheSameDay(comparedDate: Date): Boolean {
+    val calendar = Calendar.getInstance()
+    calendar.time = this.date
+    val comparedCalendarDate = Calendar.getInstance()
+    comparedCalendarDate.time = comparedDate
+    return calendar.get(Calendar.DAY_OF_YEAR) == comparedCalendarDate.get(Calendar.DAY_OF_YEAR) && calendar.get(
+        Calendar.YEAR
+    ) == comparedCalendarDate.get(Calendar.YEAR)
+}

--- a/rangedatepicker/src/main/java/com/andrewjapar/rangedatepicker/CalendarPicker.kt
+++ b/rangedatepicker/src/main/java/com/andrewjapar/rangedatepicker/CalendarPicker.kt
@@ -73,7 +73,6 @@ class CalendarPicker : RecyclerView {
 
     fun modify(func: CalendarPicker.() -> Unit): CalendarPicker {
         this.func()
-        this.refreshData()
 
         return this
     }
@@ -83,6 +82,8 @@ class CalendarPicker : RecyclerView {
 
         startCalendar.withTime(startDate)
         endCalendar.withTime(endDate)
+
+        refreshData()
     }
 
     fun showDayOfWeekTitle(show: Boolean) {
@@ -91,16 +92,17 @@ class CalendarPicker : RecyclerView {
 
     fun setSelectionDate(startDate: Date, endDate: Date? = null) {
         val startIndex =
-            mCalendarData.indexOfFirst { it is CalendarEntity.Day && it.date.time == startDate.time }
+            mCalendarData.indexOfFirst { it is CalendarEntity.Day && it.isTheSameDay(startDate) }
 
-        if (startIndex > -1) onDaySelected(
-            mCalendarData[startIndex] as CalendarEntity.Day,
-            startIndex
-        )
+        require(startIndex != -1) {
+            "Selection start date must be included in your Calendar Range Date"
+        }
+
+        onDaySelected(mCalendarData[startIndex] as CalendarEntity.Day, startIndex)
 
         if (endDate != null) {
             val endIndex =
-                mCalendarData.indexOfFirst { it is CalendarEntity.Day && it.date.time == endDate.time }
+                mCalendarData.indexOfFirst { it is CalendarEntity.Day && it.isTheSameDay(endDate) }
             if (endIndex > -1) onDaySelected(
                 mCalendarData[endIndex] as CalendarEntity.Day,
                 endIndex
@@ -139,7 +141,7 @@ class CalendarPicker : RecyclerView {
     }
 
     private fun refreshData() {
-        mCalendarData = buildCalendarData()
+       mCalendarData = buildCalendarData()
         calendarAdapter.setData(mCalendarData)
     }
 


### PR DESCRIPTION
`setSelectionDate` from modify on calendar initialization works wrong. Because the selection date can be not included in our `calendarData`, builded from mocked data on caledarPicker initializating. We need to rebuild calendar data on new range set. 

Also: `it.date.time == startDate.time` do not compare days correctly. It compare exact time, including hours and minutes. It is does not matter, wich hour in our day is chosen